### PR TITLE
faultCode can now be either an string or int.

### DIFF
--- a/response.go
+++ b/response.go
@@ -9,7 +9,7 @@ var (
 )
 
 type failedResponse struct {
-	Code  string `xmlrpc:"faultCode"`
+	Code  interface{} `xmlrpc:"faultCode"`
 	Error string `xmlrpc:"faultString"`
 	HttpStatusCode int
 }

--- a/xmlrpc.go
+++ b/xmlrpc.go
@@ -6,7 +6,7 @@ import (
 
 // xmlrpcError represents errors returned on xmlrpc request.
 type XmlRpcError struct {
-	Code           string
+	Code           interface{}
 	Err            string
 	HttpStatusCode int
 }
@@ -14,7 +14,7 @@ type XmlRpcError struct {
 // Error() method implements Error interface
 func (e *XmlRpcError) Error() string {
 	return fmt.Sprintf(
-		"error: %s, code: %s, http status code: %d",
+		"error: %s, code: %v, http status code: %d",
 		e.Err, e.Code, e.HttpStatusCode)
 }
 


### PR DESCRIPTION
Fixes type mismatch errors on decoding. 
The previous changes breaks the decoding of the error message when faultCode is an negative integer.